### PR TITLE
Update ports for use on ECS with awsvpc network type

### DIFF
--- a/cic-apache/cic-http.conf
+++ b/cic-apache/cic-http.conf
@@ -3,7 +3,7 @@ ErrorLog /usr/local/apache2/logs/error.log
 CustomLog /usr/local/apache2/logs/access.log common
 
 <IfModule mod_weblogic.c>
-    WebLogicCluster wlserver1:7001,wlserver2:7001
+    WebLogicCluster wlserver1:7002,wlserver2:7003
     ConnectTimeoutSecs 30
     WLTempDir /tmp
 </IfModule>

--- a/cic-domain/config/config.xml
+++ b/cic-domain/config/config.xml
@@ -57,7 +57,7 @@
       <file-count>7</file-count>
     </log>
     <machine>mach-wlserver1</machine>
-    <listen-port>7001</listen-port>
+    <listen-port>7002</listen-port>
     <cluster>wlcluster</cluster>
     <web-server>
       <web-server-log>
@@ -86,7 +86,7 @@
       <file-count>7</file-count>
     </log>
     <machine>mach-wlserver2</machine>
-    <listen-port>7001</listen-port>
+    <listen-port>7003</listen-port>
     <cluster>wlcluster</cluster>
     <web-server>
       <web-server-log>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     hostname: wlserver1
     image: ${CIC_APP_IMAGE:-cic-app}
     ports:
-      - "21011:7001"
+      - "21011:7002"
     volumes:
       - type: bind
         source: ./running-servers
@@ -41,7 +41,7 @@ services:
     hostname: wlserver2
     image: ${CIC_APP_IMAGE:-cic-app}
     ports:
-      - "21012:7001"
+      - "21012:7003"
     volumes:
       - type: bind
         source: ./running-servers


### PR DESCRIPTION
Whilst investigating the use of ECS, we have found that it doesn't support bi-directional communication between containers on the same host as it only supports the Docker links parameter and not the newer network parameter when using bridge networking.  The AWS recommended network type of awsvpc will allow the bi-directional communication, but it works by allocating an EIN and using that for all containers on the host within the same task.  For that to work, we need to ensure that the listen ports used on the containers are unique, as there will not be a separate ip for each container.

This PR makes the ports unique, so instead of the wladmin, wlserver1 & wlserver 2 all using 7001, wlserver1 now uses 7002 and wlserver2 uses 7003.  The Apache config has also been updated to reflect that change.

Resolves:
CM-323