### PR TITLE
Changes to support image builds in Concourse

### DIFF
--- a/cic-apache/Dockerfile
+++ b/cic-apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM ch-serverjre as builder
+FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/ch-serverjre as builder
 
 RUN mkdir -p apache/CICWEB
 
@@ -11,7 +11,7 @@ RUN cd apache && \
     cd CICWEB  && \
     jar xvf cic-web.war --directory CICWEB js/ images/ html/ css/ 
 
-FROM ch-apache
+FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/ch-apache
 
 # Add section of Apache config for the CIC app
 COPY cic-http.conf conf

--- a/cic-apache/Dockerfile
+++ b/cic-apache/Dockerfile
@@ -1,15 +1,12 @@
 FROM ch-serverjre as builder
 
-ARG RELEASE_ARTIFACT=cic-ear-1.0.zip
-ARG CIC_ZIP_URL=http://release.ch.gov.uk/chips/cics/${RELEASE_ARTIFACT}
- 
-# Download the CIC apache static content file and extract into a builder image
-# This is required as the ch-apache image does not have curl or tar available
-RUN mkdir -p apache/CICWEB && \
-    curl ${CIC_ZIP_URL} -o apache/${RELEASE_ARTIFACT}  && \
-    cd apache && \
-    unzip ${RELEASE_ARTIFACT} && \
-    jar xvf cic-ear-1.0.ear cic-web.war  && \
+RUN mkdir -p apache/CICWEB
+
+COPY cic-*.zip apache
+
+RUN cd apache && \
+    unzip *.zip && \
+    jar xvf cic-ear-*.ear cic-web.war  && \
     mv cic-web.war CICWEB && \
     cd CICWEB  && \
     jar xvf cic-web.war --directory CICWEB js/ images/ html/ css/ 

--- a/cic-apache/index.html
+++ b/cic-apache/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta http-equiv="refresh" content="0;URL=/CICWEB/examiner/home.do"> 
+</head>
+The page should refresh in a few seconds please wait <br/> 
+This is Linux CICs document root
+</html>
+

--- a/cic-app/Dockerfile
+++ b/cic-app/Dockerfile
@@ -10,7 +10,7 @@ COPY --chown=weblogic:weblogic container-scripts container-scripts/
 RUN chmod 754 container-scripts/*.sh && \
     mkdir -p ${DOMAIN_NAME}/upload
 
-COPY --chown=weblogic:weblogic artifacts/cic-*.zip ${DOMAIN_NAME}/upload/cic-ear.zip
+COPY --chown=weblogic:weblogic cic-*.zip ${DOMAIN_NAME}/upload/cic-ear.zip
 
 RUN cd ${DOMAIN_NAME}/upload && \
     unzip cic-ear.zip && \

--- a/cic-app/Dockerfile
+++ b/cic-app/Dockerfile
@@ -10,7 +10,7 @@ COPY --chown=weblogic:weblogic container-scripts container-scripts/
 RUN chmod 754 container-scripts/*.sh && \
     mkdir -p ${DOMAIN_NAME}/upload
 
-COPY --chown=weblogic:weblogic ../source-code/cic-ear-*.zip ${DOMAIN_NAME}/upload/cic-ear.zip
+COPY --chown=weblogic:weblogic source-code/cic-ear-*.zip ${DOMAIN_NAME}/upload/cic-ear.zip
 
 RUN cd ${DOMAIN_NAME}/upload && \
     unzip cic-ear.zip && \

--- a/cic-app/Dockerfile
+++ b/cic-app/Dockerfile
@@ -1,20 +1,19 @@
 FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/cic-domain
 
-ARG RELEASE_ARTIFACT=cic-ear-1.0.zip
-ARG CIC_ZIP_URL=http://release.ch.gov.uk/chips/cics/${RELEASE_ARTIFACT}
-
 # Copy over the CIC application configuration file
 COPY --chown=weblogic:weblogic config.properties ${DOMAIN_NAME}
 
 # Copy over utility scripts
 COPY --chown=weblogic:weblogic container-scripts container-scripts/
 
-# Download the CIC ZIP file into the ${DOMAIN_NAME}/upload directory on the image
+# Set permissions on utility scripts and create upload folder to receive the cic ear file 
 RUN chmod 754 container-scripts/*.sh && \
-    mkdir -p ${DOMAIN_NAME}/upload && \
-    curl ${CIC_ZIP_URL} -o ${DOMAIN_NAME}/upload/${RELEASE_ARTIFACT}  && \
-    cd ${DOMAIN_NAME}/upload && \
-    unzip ${RELEASE_ARTIFACT} && \
+    mkdir -p ${DOMAIN_NAME}/upload
+
+COPY --chown=weblogic:weblogic ../source-code/cic-ear-*.zip ${DOMAIN_NAME}/upload/cic-ear.zip
+
+RUN cd ${DOMAIN_NAME}/upload && \
+    unzip cic-ear.zip && \
     mv cic-ear*.ear CIC.ear
 
 CMD ["bash"]

--- a/cic-app/Dockerfile
+++ b/cic-app/Dockerfile
@@ -10,7 +10,7 @@ COPY --chown=weblogic:weblogic container-scripts container-scripts/
 RUN chmod 754 container-scripts/*.sh && \
     mkdir -p ${DOMAIN_NAME}/upload
 
-COPY --chown=weblogic:weblogic ../../source-code/cic-ear-*.zip ${DOMAIN_NAME}/upload/cic-ear.zip
+COPY --chown=weblogic:weblogic artifacts/cic-*.zip ${DOMAIN_NAME}/upload/cic-ear.zip
 
 RUN cd ${DOMAIN_NAME}/upload && \
     unzip cic-ear.zip && \

--- a/cic-app/Dockerfile
+++ b/cic-app/Dockerfile
@@ -10,7 +10,7 @@ COPY --chown=weblogic:weblogic container-scripts container-scripts/
 RUN chmod 754 container-scripts/*.sh && \
     mkdir -p ${DOMAIN_NAME}/upload
 
-COPY --chown=weblogic:weblogic source-code/cic-ear-*.zip ${DOMAIN_NAME}/upload/cic-ear.zip
+COPY --chown=weblogic:weblogic ../../source-code/cic-ear-*.zip ${DOMAIN_NAME}/upload/cic-ear.zip
 
 RUN cd ${DOMAIN_NAME}/upload && \
     unzip cic-ear.zip && \

--- a/cic-app/Dockerfile
+++ b/cic-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM cic-domain
+FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/cic-domain
 
 ARG RELEASE_ARTIFACT=cic-ear-1.0.zip
 ARG CIC_ZIP_URL=http://release.ch.gov.uk/chips/cics/${RELEASE_ARTIFACT}


### PR DESCRIPTION
No longer download the CIC release artifact from the release server, but instead use the one provided by the pipeline in the local folder.  Also use ECR to provide the base images.