### PR TITLE
Add auto start scripts and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ In order to use the image, a number of environment properties need to be defined
 |AD_CREDENTIAL|The password of the user in AD for connecting in order to authenticate other user logins|password
 |AD_USER_BASE_DN|The base location under which users can be found via a subtree search|OU=MySection, OU=MyOrg, DC=MyDepartment, DC=local
 |AD_GROUP_BASE_DN|The base location under which groups can be found via a subtree search|OU=MySection, OU=MyOrg, DC=MyDepartment, DC=local
+|AUTO_START_NODES|A list of managed server names to auto start when the container is launched|wlserver1,wlserver2
 
 ## docker-compose
 docker-compose can be used to start all the required containers in one operation.
@@ -74,7 +75,4 @@ The following command, executed from the root of the repo,  can be used to start
 After starting the containers, the Administration server console will be available on http://127.0.0.1:21001/console on the host.  You can login with the user `weblogic` and the password you set for `ADMIN_PASSWORD`in the properties file.
 
 ### Starting the Managed servers 
-The managed server containers will be running Node Manager, which can then be used to start up the managed server instances inside the containers using the Administration console.
-
-### Accessing the CIC application
-After starting at least one managed server, via the Administration console, you should be able to access the application on http://127.0.0.1:21000
+The managed server containers will be running Node Manager, which can then be used to start up the managed server instances inside the containers using the Administration console.  If the `AUTO_START_NODES` property is used, the servers listed will be started automatically.

--- a/cic-domain/container-scripts/await-admin-server-startup.py
+++ b/cic-domain/container-scripts/await-admin-server-startup.py
@@ -1,0 +1,45 @@
+###########################################################################
+# Attempts to connect directly to a specified WL server and if a failure occurs
+# it retries until either a connection is made or the timeout is exceeded
+###########################################################################
+#Functions
+###########################################################################
+def checkConnection(adminUsername, adminPassword, adminServerT3):
+   try:
+      connect(username=adminUsername,password=adminPassword,url=adminServerT3)
+      return true 
+   except:
+      print 'checkConnection: Failed to connect to server ', adminServerT3
+      return false
+      
+
+###########################################################################
+# Main 
+###########################################################################
+
+adminServerT3 = 't3://wladmin:7001'
+adminUsername = 'weblogic'
+adminPassword = os.environ.get("ADMIN_PASSWORD")
+timeout = 120
+
+
+#Check if the server can be connected to
+connected = checkConnection(adminUsername, adminPassword, adminServerT3)
+if (connected):
+   print 'Server is running'
+   exit()
+
+
+#Check progress of startup
+sleepmilli=10000
+waited = 0
+while (not connected):
+
+   if (waited >=timeout ):
+      print 'Server startup timed out after %i seconds' % (waited)
+      exit(exitcode=1) 
+
+   Thread.sleep(sleepmilli)
+   waited = waited + (sleepmilli/1000)
+   connected = checkConnection(adminUsername, adminPassword, adminServerT3)
+   print 'Connection status', connected

--- a/cic-domain/container-scripts/start-managed-server.py
+++ b/cic-domain/container-scripts/start-managed-server.py
@@ -1,0 +1,29 @@
+################################################################
+# Starts a specified WL managed server using the admin server
+# The Admin server must be running
+################################################################
+#Functions
+################################################################
+def getServerStatus(svrName):
+   slrBean = cmo.lookupServerLifeCycleRuntime(svrName)
+   return slrBean.getState()
+
+adminServerT3 = 't3://wladmin:7001'
+adminUsername = 'weblogic'
+adminPassword = os.environ.get("ADMIN_PASSWORD")
+srvName = os.environ.get("HOSTNAME")
+
+#Connect to admin server 
+connect(username=adminUsername, password=adminPassword, url=adminServerT3)
+
+domainRuntime()
+
+#Check if the server is already running
+serverStatus = getServerStatus(srvName)
+if (serverStatus == 'RUNNING'):
+   print 'Server is already running'
+   exit()
+
+
+#Start the server async
+start(srvName,'Server',block='false')

--- a/cic-domain/container-scripts/startAdmin.sh
+++ b/cic-domain/container-scripts/startAdmin.sh
@@ -28,4 +28,7 @@ ${ORACLE_HOME}/wlserver/common/bin/wlst.sh ${ORACLE_HOME}/container-scripts/set-
 # Set the managed server startup arguments
 sed -i "s/@start-args@/${START_ARGS}/g" ${DOMAIN_HOME}/config/config.xml
 
+# Prevent Derby from being started
+export DERBY_FLAG=false
+
 ${DOMAIN_HOME}/bin/startWebLogic.sh $*

--- a/cic-domain/container-scripts/startManagedServer.sh
+++ b/cic-domain/container-scripts/startManagedServer.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+DOMAIN_HOME="/apps/oracle/${DOMAIN_NAME}"
+. ${DOMAIN_HOME}/bin/setDomainEnv.sh
+
+env
+
+if [[ ${AUTO_START_NODES} =~ ${HOSTNAME} ]]; then
+  echo "This node (${HOSTNAME}) is configured to auto start, so now attempting to start it."
+else
+  echo "This node (${HOSTNAME}) is NOT configured to auto start, so skipping startup."
+  exit
+fi
+
+echo "Awaiting startup of the admin server"
+${ORACLE_HOME}/wlserver/common/bin/wlst.sh ${ORACLE_HOME}/container-scripts/await-admin-server-startup.py
+if [ $? -eq 0 ]; then
+  echo "Admin server is running, so starting managed server"
+
+  ${ORACLE_HOME}/wlserver/common/bin/wlst.sh ${ORACLE_HOME}/container-scripts/start-managed-server.py
+else
+
+  echo "Admin server is not running, or has not started within timeout"
+fi

--- a/cic-domain/container-scripts/startNodeManagerAndManagedServer.sh
+++ b/cic-domain/container-scripts/startNodeManagerAndManagedServer.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Prevent Derby from being started
+export DERBY_FLAG=false
+
+# Launch managed server startup in a separate process
+( ${ORACLE_HOME}/container-scripts/startManagedServer.sh ) > ${ORACLE_HOME}/auto-start.log  &
+
+${ORACLE_HOME}/container-scripts/startNodeManager.sh
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     networks:
       - cic-net
     env_file: ./cic.properties
-    entrypoint: container-scripts/setConfigAndStartNM.sh
+    entrypoint: container-scripts/startNodeManagerAndManagedServer.sh
   wlserver2:
     hostname: wlserver2
     image: ${CIC_APP_IMAGE:-cic-app:latest}
@@ -49,6 +49,6 @@ services:
     networks:
       - cic-net
     env_file: ./cic.properties
-    entrypoint: container-scripts/setConfigAndStartNM.sh
+    entrypoint: container-scripts/startNodeManagerAndManagedServer.sh
 networks:
   cic-net: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - cic-net
   wladmin:
     hostname: wladmin
-    image: ${CIC_APP_IMAGE:-cic-app:latest}
+    image: ${CIC_APP_IMAGE:-cic-domain:latest}
     ports:
       - "21001:7001"
     volumes:
@@ -26,7 +26,7 @@ services:
     entrypoint: container-scripts/startAdmin.sh
   wlserver1:
     hostname: wlserver1
-    image: ${CIC_APP_IMAGE:-cic-app:latest}
+    image: ${CIC_APP_IMAGE:-cic-domain:latest}
     ports:
       - "21011:7001"
     volumes:
@@ -39,7 +39,7 @@ services:
     entrypoint: container-scripts/startNodeManagerAndManagedServer.sh
   wlserver2:
     hostname: wlserver2
-    image: ${CIC_APP_IMAGE:-cic-app:latest}
+    image: ${CIC_APP_IMAGE:-cic-domain:latest}
     ports:
       - "21012:7001"
     volumes:


### PR DESCRIPTION
Adds the scripts needed to await the startup of the admin server and automatically start the managed servers specified in the AUTO_START_NODES property.

Resolves:
CM-643