### PR TITLE
Set weblogic-plugin-enabled=true

### DIFF
--- a/cic-domain/config/config.xml
+++ b/cic-domain/config/config.xml
@@ -74,6 +74,7 @@
       <hostname-verification-ignored>true</hostname-verification-ignored>
     </ssl>
     <listen-address>wladmin</listen-address>
+    <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
   </server>
   <server>
     <name>wlserver1</name>
@@ -104,6 +105,7 @@
       <user-preferred-server>wlserver1</user-preferred-server>
       <cluster>wlcluster</cluster>
     </jta-migratable-target>
+    <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
   </server>
   <server>
     <name>wlserver2</name>
@@ -134,6 +136,7 @@
       <user-preferred-server>wlserver2</user-preferred-server>
       <cluster>wlcluster</cluster>
     </jta-migratable-target>
+    <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
   </server>
   <cluster>
     <name>wlcluster</name>


### PR DESCRIPTION
An issue was found with WebLogic admin server access when testing CM-649.  This change, along with a change to the apache configuration allows the servers to know that they are being accessed via HTTPS, despite the SSL being terminated at the ALB.