### PR TITLE
Reference version 1.5.2 of ch-weblogic to bring in new chca cert

### DIFF
--- a/cic-domain/Dockerfile
+++ b/cic-domain/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:1.5.0
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:1.5.2
 
 # IMPORTANT - the default admin password should be supplied as a build arg
 # e.g. --build-arg ADMIN_PASSWORD=notsecure123.  This password will be visible in the image


### PR DESCRIPTION
The new cert is included in ch-weblogic-1.5.2. The new cert is needed as the previous cert is due to expire on 6th Aug.

Resolves:
https://companieshouse.atlassian.net/browse/SUP-1124
